### PR TITLE
fix(db): prevent JDBC URL issues when password contains special characters

### DIFF
--- a/src/main/java/dev/entree/vchest/JDBCUtils.java
+++ b/src/main/java/dev/entree/vchest/JDBCUtils.java
@@ -22,6 +22,10 @@ public class JDBCUtils {
                 ? String.format("jdbc:%s:%s", protocol, new File(dbDir, dbName + ".db").getAbsolutePath())
                 : String.format("jdbc:%s://%s:%s/%s?createDatabaseIfNotExist=true&user=%s&password=%s&useSSL=false&allowPublicKeyRetrieval=true&useAffectedRows=true", protocol, host, port, dbName, username, password);
         hikariConfig.setJdbcUrl(url);
+        if (dbDir == null) {
+            hikariConfig.setUsername(username);
+            hikariConfig.setPassword(password);
+        }
         return new HikariDataSource(hikariConfig);
     }
 


### PR DESCRIPTION
Moved username and password assignment to `hikariConfig.setUsername()` and `hikariConfig.setPassword()`.
Prevented credentials from being embedded in the JDBC URL string.
Ensured database connections work correctly with passwords containing special characters.